### PR TITLE
Fix unclean union

### DIFF
--- a/inserter/inserter.c
+++ b/inserter/inserter.c
@@ -17,7 +17,7 @@ const char* generate_line_protocol(speedwire_data_t* data, const char* meas_name
 
     for (obis_data_t * obis_ptr=data->obis_data_list;obis_ptr != NULL; obis_ptr = obis_ptr->next) {
 //        printf("LINE %s: %ld\n", obis_ptr->property_name, obis_ptr->counter);
-        if (asprintf(&save_ptr, "%s%s=%ld", line_buffer, obis_ptr->property_name, obis_ptr->counter) < 0) {
+        if (asprintf(&save_ptr, "%s%s=%ld", line_buffer, obis_ptr->property_name, obis_ptr->value) < 0) {
             return NULL;
         }
         free(line_buffer);

--- a/speedwire/speedwire.c
+++ b/speedwire/speedwire.c
@@ -59,7 +59,7 @@ void handle_packet(const unsigned char *msgbuf, int nbytes, struct sockaddr_in *
             obis_data_new = malloc(sizeof(obis_data_t));
             // TODO: error handling
             if (obis_data_new == NULL) exit(-1);
-            obis_data_new->actual = ntohl(*(uint32_t *)&msgbuf[offset]);
+            obis_data_new->value = ntohl(*(uint32_t *)&msgbuf[offset]);
             if (asprintf(&obis_data_new->property_name, "%s_act", name) < 0) {
                 exit(-1);
             }
@@ -76,7 +76,7 @@ void handle_packet(const unsigned char *msgbuf, int nbytes, struct sockaddr_in *
             obis_data_new = malloc(sizeof(obis_data_t));
             // TODO: error handling
             if (obis_data_new == NULL) exit(-1);
-            obis_data_new->counter = be64toh(*(uint64_t *)&msgbuf[offset]);
+            obis_data_new->value = be64toh(*(uint64_t *)&msgbuf[offset]);
             if (asprintf(&obis_data_new->property_name, "%s_cnt", name) < 0) {
                 exit(-1);
             }

--- a/speedwire/speedwire.h
+++ b/speedwire/speedwire.h
@@ -28,10 +28,7 @@ typedef struct obis_header_t {
 typedef struct obis_data_t {
     struct obis_data_t* next;
     char* property_name;
-    union {
-        uint32_t actual;
-        uint64_t counter;
-    };
+    uint64_t value;
 } obis_data_t;
 
 typedef struct speedwire_data_t {

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -42,7 +42,7 @@ static void test_handle_pkt0(void **state) {
 
     while (obis_ptr != NULL) {
         // TODO: run asserts against obis
-        printf("%s: %ld\n", obis_ptr->property_name, obis_ptr->counter);
+        printf("%s: %ld\n", obis_ptr->property_name, obis_ptr->value);
 
         obis_ptr=obis_ptr->next;
     }
@@ -60,7 +60,7 @@ static void test_handle_pkt1(void **state) {
     obis_data_t * obis_ptr = speedwire_data.obis_data_list;
     while (obis_ptr != NULL) {
 
-        printf("%s: %ld\n", obis_ptr->property_name, obis_ptr->counter);
+        printf("%s: %ld\n", obis_ptr->property_name, obis_ptr->value);
 
         obis_ptr=obis_ptr->next;
     }


### PR DESCRIPTION
Using a 32bit integer inside an union also containing a 64bit integer on heap without clearing residual values cause in corrupt measurement values.